### PR TITLE
Add "approvalWindowTtl" attribute to gateway account

### DIFF
--- a/spec/definitions/GatewayAccount.yaml
+++ b/spec/definitions/GatewayAccount.yaml
@@ -62,6 +62,12 @@ properties:
     type: number
     format: double
     minimum: 0
+  approvalWindowTtl:
+    description: The time window (in seconds) allotted for approving a suspended transaction before it is automatically canceled
+    type: integer
+    default: 3600
+    minimum: 300
+    maximum: 1296000
   threeDSecure:
     description: True, if Gateway Account allows 3DSecure
     type: boolean


### PR DESCRIPTION
New functionality on Gateway Accounts to allow merchants to specify the allotted time for a transaction approval to happen, before it is automatically canceled by Rebilly.