### PR TITLE
Add API credentials for iCheque and Payr gatewayConfig

### DIFF
--- a/spec/definitions/GatewayAccountConfig/Payr.yaml
+++ b/spec/definitions/GatewayAccountConfig/Payr.yaml
@@ -17,6 +17,12 @@ allOf:
             type: string
             description: Payr Gateway secret word
             format: password
+          apiUserId:
+            type: string
+            description: Username for the Alliance API (transaction reporting)
+          apiSecurityToken:
+            type: string
+            description: Hash of the password for the Alliance API (transaction reporting)
         required:
           - "clientId"
           - "secretWord"

--- a/spec/definitions/GatewayAccountConfig/Payr.yaml
+++ b/spec/definitions/GatewayAccountConfig/Payr.yaml
@@ -23,6 +23,7 @@ allOf:
           apiSecurityToken:
             type: string
             description: Hash of the password for the Alliance API (transaction reporting)
+            format: password
         required:
           - "clientId"
           - "secretWord"

--- a/spec/definitions/GatewayAccountConfig/iCheque.yaml
+++ b/spec/definitions/GatewayAccountConfig/iCheque.yaml
@@ -17,6 +17,12 @@ allOf:
             type: string
             description: iCheque Gateway secret word
             format: password
+          apiUserId:
+            type: string
+            description: Username for the Alliance API (transaction reporting)
+          apiSecurityToken:
+            type: string
+            description: Hash of the password for the Alliance API (transaction reporting)
         required:
           - "clientId"
           - "secretWord"

--- a/spec/definitions/GatewayAccountConfig/iCheque.yaml
+++ b/spec/definitions/GatewayAccountConfig/iCheque.yaml
@@ -23,6 +23,7 @@ allOf:
           apiSecurityToken:
             type: string
             description: Hash of the password for the Alliance API (transaction reporting)
+            format: password
         required:
           - "clientId"
           - "secretWord"


### PR DESCRIPTION
These credentials are used for the Alliance reporting API.