### PR TITLE
Rename gateway GlobalCollect to Ingenico

### DIFF
--- a/spec/components/schemas/GatewayAccountConfig/Ingenico.yaml
+++ b/spec/components/schemas/GatewayAccountConfig/Ingenico.yaml
@@ -1,4 +1,4 @@
-description: GlobalCollect Gateway config
+description: Ingenico Gateway config
 allOf:
   -
     $ref: "#/components/schemas/GatewayAccount"
@@ -12,20 +12,20 @@ allOf:
         properties:
           merchantId:
             type: string
-            description: GlobalCollect Gateway merchant ID
+            description: Ingenico Gateway merchant ID
           apiKeyId:
             type: string
-            description: GlobalCollect Gateway api key ID
+            description: Ingenico Gateway api key ID
           apiSecretKey:
             type: string
-            description: GlobalCollect Gateway api secret key
+            description: Ingenico Gateway api secret key
             format: password
           skipFraudService:
             type: boolean
-            description: GlobalCollect skip fraud service
+            description: Ingenico skip fraud service
         required:
           - "merchantId"
           - "apiKeyId"
           - "apiSecretKey"
       mpi:
-        $ref: "#/components/schemas/GlobalCollectMpis"
+        $ref: "#/components/schemas/IngenicoMpis"

--- a/spec/components/schemas/Gateways/MpiName.yaml
+++ b/spec/components/schemas/Gateways/MpiName.yaml
@@ -6,7 +6,7 @@ enum:
  - IlixiumMpi
  - DataCashMpi
  - OptimalMpi
- - GlobalCollectMpi
+ - IngenicoMpi
  - CardinalCommerce
  - PaayMpi
  - Panamerican

--- a/spec/components/schemas/Mpi/GlobalCollectMpis/GlobalCollectMpi.yaml
+++ b/spec/components/schemas/Mpi/GlobalCollectMpis/GlobalCollectMpi.yaml
@@ -1,4 +1,0 @@
-description: GlobalCollect Integrated
-allOf:
-  -
-    $ref: "#/components/schemas/GlobalCollectMpis"

--- a/spec/components/schemas/Mpi/IngenicoMpis/IngenicoMpi.yaml
+++ b/spec/components/schemas/Mpi/IngenicoMpis/IngenicoMpi.yaml
@@ -1,0 +1,4 @@
+description: Ingenico Integrated
+allOf:
+  -
+    $ref: "#/components/schemas/IngenicoMpis"

--- a/spec/components/schemas/Mpi/IngenicoMpis/IngenicoMpis.yaml
+++ b/spec/components/schemas/Mpi/IngenicoMpis/IngenicoMpis.yaml
@@ -1,4 +1,4 @@
-description: GlobalCollect Mpis
+description: Ingenico Mpis
 discriminator:
   propertyName: name
 type: object
@@ -9,4 +9,4 @@ properties:
     allOf:
       - $ref: "#/components/schemas/MpiName"
     enum:
-     - GlobalCollectMpi
+     - IngenicoMpi


### PR DESCRIPTION
Previously `GlobalCollect` was renamed to `Ingenico`. This PR applies that change for all related files.