### PR TITLE
Make INOVAPAY API key not a secret

### DIFF
--- a/spec/components/schemas/GatewayAccountConfig/INOVAPAY.yaml
+++ b/spec/components/schemas/GatewayAccountConfig/INOVAPAY.yaml
@@ -14,7 +14,6 @@ allOf:
           apiKey:
             type: string
             description: INOVAPAY API key
-            format: password
           apiSecret:
             type: string
             description: INOVAPAY API secret


### PR DESCRIPTION
This PR will make API key not a secret credential for INOVAPAY.

According to INOVAPAY doc ApiKey may be displayed to user and used as a part of url to redirect customer to