### PR TITLE
Add sandbox setting to Gigadat

### DIFF
--- a/spec/components/schemas/GatewayAccountConfig/Gigadat.yaml
+++ b/spec/components/schemas/GatewayAccountConfig/Gigadat.yaml
@@ -35,5 +35,10 @@ allOf:
             enum:
               - e-transfer
               - ACH
+          sandbox:
+            type: boolean
+            description: True if gateway account is in sandbox mode
+            default: false
         required:
           - "payoutMethod"
+          - "sandbox"


### PR DESCRIPTION
This is needed for testing Gigadat gateway account with live environment.