### PR TITLE
Add NETELLERgo! setting for Neteller gateways

### DIFF
--- a/spec/components/schemas/GatewayAccountConfig/Neteller.yaml
+++ b/spec/components/schemas/GatewayAccountConfig/Neteller.yaml
@@ -26,3 +26,10 @@ allOf:
           - "clientId"
           - "clientSecret"
           - "webhookSecretKey"
+      settings:
+        type: object
+        description: Neteller settings object
+        properties:
+          netellerGo:
+            type: boolean
+            description: Enable NETELLERgo! payment flow


### PR DESCRIPTION
Defines an additional gateway account config setting, allowing to choose between Neteller direct transfer and NETELLERgo! payment flows.