### PR TITLE
Display Email Delivery Settings in tag group

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -219,6 +219,7 @@ x-tagGroups:
   - name: Email
     tags:
       - Email Credentials
+      - Email Delivery Settings
       - Email Messages
   - name: Rules
     tags:


### PR DESCRIPTION
Fixes issue in https://github.com/Rebilly/RebillyUserAPI/pull/282 