### PR TITLE
Localization support v4

### DIFF
--- a/spec/components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
+++ b/spec/components/schemas/EmailDeliverySettings/EmailDeliverySetting.yaml
@@ -9,7 +9,9 @@ properties:
     allOf:
       - $ref: "#/components/schemas/ResourceId"
   from:
-    description: The sender's email address
+    description: >
+      The sender's email address.  It must be unique within
+      your account.
     type: string
     format: email
     maxLength: 254

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -18,22 +18,18 @@ properties:
     maximum: 100
     example: 75
     default: 100
-  defaultLocale:
-    type: string
-    description: >
-      The value should be a language locale identifier according to [RFC 5646](https://tools.ietf.org/html/rfc5646). 
-      
-      This property will be used as a surrogate for the recipient's locale in two cases:
-        
-        1. When the recipient has no locale set. 
-        2. When the recipient's locale has no matching corresponding message. 
-      
-      There SHOULD be a message with a matching locale value, or else
-      another message will be sent.
-
-    default: en-US
   message:
-    description: An array of messages with the language locale identifiers according to [RFC 5646](https://tools.ietf.org/html/rfc5646).
+    description: >
+      An array of messages with the language locale identifiers according to [RFC 5646](https://tools.ietf.org/html/rfc5646).
+      
+      A language will be selected based on the customer's locale. If there is 
+      no locale set, then `en-US` will be used as the default locale.
+
+      If there is no message with that `en-US` locale, then a message
+      will be sent and the locale may be selected at random.  
+
+      To provide the best experience for customers, if you're email messages 
+      are localized into more than one language, you SHOULD set a customer locale.
     type: array
     items:
       type: object

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -44,6 +44,7 @@ properties:
       For example, `Hello {{invalid.placeholder}}!`  will be rendered to `Hello !`.
 
     type: array
+    minItems: 1
     items:
       type: object
       required:

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -40,7 +40,7 @@ properties:
       you SHOULD set a customer locale.
 
 
-      It should be noted that an invalid placeholder will render to an empty string.
+      An invalid placeholder will render to an empty string.
       For example, `Hello {{invalid.placeholder}}!`  will be rendered to `Hello !`.
 
     type: array

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -49,24 +49,38 @@ properties:
           example: fr-FR
         from:
           type: string
-          description: The sender address. Template placeholders are allowed.
+          description: >
+            The sender address. Template placeholders are allowed. 
+            If a placeholder does not resolve to a **verified** from
+            address, then the default verified from address will be used
+            instead.  
+            # todo add a link to help docs on how to verify an email address
           maxLength: 254
         to:
           type: array
-          description: The recipients addresses. Template placeholders are allowed.
+          description: > 
+            The recipients addresses. Template placeholders are allowed.
+            If a placeholder does not resolve to an email address, then
+            no email will be sent.
           minItems: 1
           items:
             type: string
             maxLength: 254
         cc:
           type: array
-          description: The recipients addresses. Template placeholders are allowed.
+          description: > 
+            The recipients to be carbon copied addresses. Template placeholders are allowed.
+            If a placeholder does not resolve to an email address, then
+            they will not be added to the cc.
           items:
             type: string
             maxLength: 254
         bcc:
           type: array
-          description: The blind carbon copy recipients addresses. Template placeholders are allowed.
+          description: > 
+            The blind carbon copy recipients addresses. Template placeholders are allowed.
+            If a placeholder does not resolve to an email address, then
+            they will not be added to the cc.
           items:
             type: string
             maxLength: 254

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -138,8 +138,8 @@ properties:
                     example: "INV-1"
       example:
         locale: fr-FR
-        from: example@example.com
-        to: {{ invoice.customer.email }}
+        from: ["example@example.com"]
+        to: ["{{ invoice.customer.email }}"]
         subject: Sujet de démonstration
         text: Texte de démonstration
         html: <p>Texte de démonstration</p>

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -21,15 +21,19 @@ properties:
   message:
     description: >
       An array of messages with the language locale identifiers according to [RFC 5646](https://tools.ietf.org/html/rfc5646).
+      A language will be selected based on the customer's locale.
+
       
-      A language will be selected based on the customer's locale. If there is 
-      no locale set, then `en-US` will be used as the default locale.
+      If there is no locale set for the customer, then `en-US` (US English) will be used as the locale.
 
-      If there is no message with that `en-US` locale, then a message
-      will be sent and the locale may be selected at random.  
 
-      To provide the best experience for customers, if you're email messages 
-      are localized into more than one language, you SHOULD set a customer locale.
+      If there is no message with the customer's locale, 
+      then a message locale will be selected by Rebilly using a closest
+      match algorithm (which may be random at worst).
+
+
+      If your email messages are localized into more than one language, 
+      you SHOULD set a customer locale.
     type: array
     items:
       type: object
@@ -65,7 +69,25 @@ properties:
             The source of the message required for the email editor.
             Not used for sending emails.
             Used by the editor to reproduce the message for future updates.
-    example:
+        attachments:
+              description: The message's attachments
+              type: array
+              items:
+                type: object
+                required:
+                  - resourceType
+                  - resourceId
+                properties:
+                  resourceType:
+                    description: The attachment's resource type.
+                    type: string
+                    example: "invoice"
+                  resourceId:
+                    description: The attachment's resource identifier string. The template placeholders are allowed.
+                    type: string
+                    maxLength: 255
+                    example: "INV-1"
+      example:
         locale: fr-FR
         subject: Sujet de démonstration
         text: Texte de démonstration

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -4,79 +4,13 @@ properties:
     type: string
     format: uuid
     description: The message identifier string.
+    # is this readOnly?
   credentialHash:
     type: string
     description: SMTP or Mailgun credential identifier string.
   version:
     type: string
     description: The message version. (By default is empty, but if you make multiple versions, you can name or number them to distinguish them.)
-  defaultLocale:
-    type: string
-    description: The language locale identifier according to RFC 5646
-    default: en-US
-  from:
-    type: string
-    description: The sender address. The template placeholders are allowed.
-    maxLength: 254
-  to:
-    type: array
-    description: The recipients addresses. The template placeholders are allowed.
-    minItems: 1
-    items:
-      type: string
-      maxLength: 254
-  cc:
-    type: array
-    description: The recipients addresses. The template placeholders are allowed.
-    items:
-      type: string
-      maxLength: 254
-  bcc:
-    type: array
-    description: The hidden recipients addresses. The template placeholders are allowed.
-    items:
-      type: string
-      maxLength: 254
-  subject:
-    type: string
-    description: The message subject. The template placeholders are allowed.
-    maxLength: 998
-  text:
-    type: string
-    description: |
-      The message's text body.
-      Leave empty to use content from "bodyHtml".
-      The template placeholders are allowed.
-  html:
-    type: string
-    description: |
-      The message's html body.
-      Leave empty to use content from "bodyText".
-      The template placeholders are allowed.
-  editor:
-    type: string
-    description: |
-      The source of the message required for the email editor.
-      Not used for sending emails.
-      Used by the editor to reproduce the message for future updates.
-  attachments:
-    description: The message's attachments
-    type: array
-    items:
-      type: object
-      required:
-        - resourceType
-        - resourceId
-      properties:
-        resourceType:
-          description: The attachment's resource type.
-          type: string
-          example: "invoice"
-        resourceId:
-          description: The attachment's resource identifier string. The template placeholders are allowed.
-          type: string
-          maxLength: 255
-          example: "INV-1"
   weight:
     type: integer
     description: The message's weight.
@@ -84,8 +18,22 @@ properties:
     maximum: 100
     example: 75
     default: 100
-  localization:
-    description: An array of body objects mapped to the language locale identifiers according to RFC 5646
+  defaultLocale:
+    type: string
+    description: >
+      The value should be a language locale identifier according to [RFC 5646](https://tools.ietf.org/html/rfc5646). 
+      
+      This property will be used as a surrogate for the recipient's locale in two cases:
+        
+        1. When the recipient has no locale set. 
+        2. When the recipient's locale has no matching corresponding message. 
+      
+      There SHOULD be a message with a matching locale value, or else
+      another message will be sent.
+
+    default: en-US
+  message:
+    description: An array of messages with the language locale identifiers according to [RFC 5646](https://tools.ietf.org/html/rfc5646).
     type: array
     items:
       type: object
@@ -97,11 +45,11 @@ properties:
       properties:
         locale:
           type: string
-          description: The language locale identifier according to RFC 5646
+          description: The language locale identifier according to [RFC 5646](https://tools.ietf.org/html/rfc5646).
           example: fr-FR
         subject:
           type: string
-          description: The message subject. The template placeholders are allowed.
+          description: The message subject. Template placeholders are allowed.
           maxLength: 998
         text:
           type: string
@@ -122,14 +70,11 @@ properties:
             Not used for sending emails.
             Used by the editor to reproduce the message for future updates.
     example:
-      fr-FR:
+        locale: fr-FR
         subject: Sujet de démonstration
         text: Texte de démonstration
         html: <p>Texte de démonstration</p>
         editor: <div class="block">Texte de démonstration</div>
 required:
   - from
-  - to
-  - subject
-  - text
-  - html
+  - message

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -17,7 +17,11 @@ properties:
       The value for random-weighted picking of a template in the case of a split test.
 
       The split test algorithm does not factor localization when
-      making a weighted-random template selection. 
+      making a weighted-random template selection.  Therefore, a version
+      will be selected first, and then after a version is selected a specific
+      localization will be selected.  Take the case where two versions have 
+      different locale content -- the locales of the content is not considered
+      when selecting the version.  
     minimum: 0
     maximum: 100
     example: 75
@@ -132,7 +136,7 @@ properties:
                     type: string
                     example: "invoice"
                   resourceId:
-                    description: The attachment's resource identifier string. The template placeholders are allowed.
+                    description: The attachment's resource identifier string. Template placeholders are allowed.
                     type: string
                     maxLength: 255
                     example: "INV-1"

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -4,7 +4,6 @@ properties:
     type: string
     format: uuid
     description: The message identifier string.
-    # is this readOnly?
   credentialHash:
     type: string
     description: SMTP or Mailgun credential identifier string.

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -10,30 +10,39 @@ properties:
     description: SMTP or Mailgun credential identifier string.
   version:
     type: string
-    description: The message version. (By default is empty, but if you make multiple versions, you can name or number them to distinguish them.)
+    description: The message version (useful for split tests). (By default is empty, but if you make multiple versions, you can name or number them to distinguish them.)
   weight:
     type: integer
-    description: The message's weight.
+    description: > 
+      The value for random-weighted picking of a template in the case of a split test.
+
+      The split test algorithm does not factor localization when
+      making a weighted-random template selection. 
     minimum: 0
     maximum: 100
     example: 75
     default: 100
-  message:
+  templates:
     description: >
-      An array of messages with the language locale identifiers according to [RFC 5646](https://tools.ietf.org/html/rfc5646).
+      An array of message templates with the language locale identifiers according to [RFC 5646](https://tools.ietf.org/html/rfc5646).
       A language will be selected based on the customer's locale.
 
       
       If there is no locale set for the customer, then `en-US` (US English) will be used as the locale.
 
 
-      If there is no message with the customer's locale, 
-      then a message locale will be selected by Rebilly using a closest
+      If there is no template with the customer's locale, 
+      then a template locale will be selected by Rebilly using a closest
       match algorithm (which may be random at worst).
 
 
-      If your email messages are localized into more than one language, 
+      If your email message templates are localized into more than one language, 
       you SHOULD set a customer locale.
+
+
+      It should be noted that an invalid placeholder will render to an empty string.
+      For example, `Hello {{invalid.placeholder}}!`  will be rendered to `Hello !`.
+
     type: array
     items:
       type: object
@@ -42,6 +51,8 @@ properties:
         - subject
         - text
         - html
+        - from
+        - to
       properties:
         locale:
           type: string
@@ -93,13 +104,13 @@ properties:
           description: |
             The message's text body.
             Leave empty to use content from "html".
-            The template placeholders are allowed.
+            Template placeholders are allowed.
         html:
           type: string
           description: |
             The message's html body.
             Leave empty to use content from "text".
-            The template placeholders are allowed.
+            Template placeholders are allowed.
         editor:
           type: string
           description: |
@@ -131,5 +142,4 @@ properties:
         html: <p>Texte de démonstration</p>
         editor: <div class="block">Texte de démonstration</div>
 required:
-  - from
-  - message
+  - templates

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -138,6 +138,8 @@ properties:
                     example: "INV-1"
       example:
         locale: fr-FR
+        from: example@example.com
+        to: {{ invoice.customer.email }}
         subject: Sujet de démonstration
         text: Texte de démonstration
         html: <p>Texte de démonstration</p>

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -47,6 +47,29 @@ properties:
           type: string
           description: The language locale identifier according to [RFC 5646](https://tools.ietf.org/html/rfc5646).
           example: fr-FR
+        from:
+          type: string
+          description: The sender address. Template placeholders are allowed.
+          maxLength: 254
+        to:
+          type: array
+          description: The recipients addresses. Template placeholders are allowed.
+          minItems: 1
+          items:
+            type: string
+            maxLength: 254
+        cc:
+          type: array
+          description: The recipients addresses. Template placeholders are allowed.
+          items:
+            type: string
+            maxLength: 254
+        bcc:
+          type: array
+          description: The blind carbon copy recipients addresses. Template placeholders are allowed.
+          items:
+            type: string
+            maxLength: 254
         subject:
           type: string
           description: The message subject. Template placeholders are allowed.

--- a/spec/components/schemas/Rules/RulesEmailNotification.yaml
+++ b/spec/components/schemas/Rules/RulesEmailNotification.yaml
@@ -4,9 +4,6 @@ properties:
     type: string
     format: uuid
     description: The message identifier string.
-  credentialHash:
-    type: string
-    description: SMTP or Mailgun credential identifier string.
   version:
     type: string
     description: The message version (useful for split tests). (By default is empty, but if you make multiple versions, you can name or number them to distinguish them.)


### PR DESCRIPTION
This is my preferred proposal.  Summary of key changes:

1. Remove credentialHash from the request. The system should look that up based on the `from` email address.
2. Created `templates` array of messages with the localization in there.
3. Added explanations for how our system processes different types of data and handles different scenarios -- for example, when a `from` placeholder doesn't resolve to a verified from email address.  Explained how our system handles more concept concepts like weights.